### PR TITLE
feat: Display article tags on homepage and article pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,3 +31,15 @@ body {
   color: var(--foreground);
   /* CSS変数を使用 */
 }
+
+.tag-badge {
+  display: inline-block;
+  background-color: #e0e0e0; /* Light gray */
+  color: #333333; /* Dark gray text */
+  padding: 0.25em 0.5em;
+  margin-right: 0.5em;
+  margin-bottom: 0.5em; /* Added for spacing when tags wrap */
+  border-radius: 0.25rem;
+  font-size: 0.875em;
+  font-weight: 600; /* Semibold, similar to previous Tailwind class */
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,6 +54,15 @@ export default async function Home() { // async関数に変更
                                     {post.excerpt}
                                 </p>
                             )}
+                            {post.tags && post.tags.length > 0 && (
+                                <div className="mt-2">
+                                    {post.tags.map((tag) => (
+                                        <span key={tag} className="tag-badge">
+                                            {tag}
+                                        </span>
+                                    ))}
+                                </div>
+                            )}
                         </article>
                     ))}
                 </section>

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -25,6 +25,16 @@ export default async function PostPage({ params }: Props) {
                 <h1 className="text-3xl text-gray-700 font-bold mb-2">{post.title}</h1>
                 <p className="text-sm text-gray-500 mb-6">{post.date}</p>
 
+                {post.tags && post.tags.length > 0 && (
+                    <div className="mb-4">
+                        {post.tags.map((tag) => (
+                            <span key={tag} className="tag-badge">
+                                {tag}
+                            </span>
+                        ))}
+                    </div>
+                )}
+
                 <article className="prose"
                     dangerouslySetInnerHTML={{ __html: post.contentHtml }}>
                 </article>

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -21,6 +21,15 @@ export default async function PostsPage() {
                             </h2>
                         </Link>
                         <p className="text-gray-500 text-sm">{post.date}</p>
+                        {post.tags && post.tags.length > 0 && (
+                            <div className="mt-2">
+                                {post.tags.map((tag) => (
+                                    <span key={tag} className="tag-badge">
+                                        {tag}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
                     </li>
                 ))}
             </ul>


### PR DESCRIPTION
This commit introduces the functionality to display tags for articles across the website.

Changes include:
- Modified the individual post page (`src/app/posts/[slug]/page.tsx`) to show tags associated with the post.
- Modified the posts list page (`src/app/posts/page.tsx`) to show tags for each post in the list.
- Modified the homepage (`src/app/page.tsx`) to display tags for each of the 5 latest articles.
- Added a CSS class `tag-badge` and corresponding styles in `src/app/globals.css` to render tags as distinct badges.

Tags are sourced from the `tags` field in the frontmatter of markdown files. If a post has no tags, the tag display section is not rendered. The existing branch `feature/display-article-tags` will be updated.