### PR TITLE
feat: 記事内の画像クリックでモーダル拡大表示を実装

### DIFF
--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { getAllPosts, getPostData } from '@/lib/posts';
 import { notFound } from 'next/navigation';
 import { Sidebar } from '@/components/Sidebar';
+import { PostContent } from '@/components/PostContent';
 
 type Props = {
     params: Promise<{
@@ -37,10 +38,7 @@ export default async function PostPage({ params }: Props) {
                         </div>
                     )}
 
-                    <article
-                        className="prose max-w-none"
-                        dangerouslySetInnerHTML={{ __html: post.contentHtml }}
-                    />
+                    <PostContent contentHtml={post.contentHtml} />
                 </main>
                 <Sidebar />
             </div>

--- a/src/components/ImageModal/index.tsx
+++ b/src/components/ImageModal/index.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useCallback } from 'react';
+import Image from 'next/image';
+
+type ImageModalProps = {
+    src: string;
+    alt: string;
+    onClose: () => void;
+};
+
+/**
+ * 画像を拡大表示するモーダルコンポーネント
+ * - オーバーレイ（背景）クリックで閉じる
+ * - ESCキーで閉じる
+ * - 画像本体のクリックは閉じない（バブリング停止）
+ */
+export function ImageModal({ src, alt, onClose }: ImageModalProps) {
+    // ESCキーが押されたらモーダルを閉じる
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onClose();
+            }
+        },
+        [onClose]
+    );
+
+    useEffect(() => {
+        // モーダル表示中はスクロールを無効化
+        document.body.style.overflow = 'hidden';
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            // クリーンアップ: スクロール復元とイベントリスナー削除
+            document.body.style.overflow = '';
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [handleKeyDown]);
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+            onClick={onClose}
+            role="dialog"
+            aria-modal="true"
+            aria-label={alt}
+        >
+            {/* 閉じるボタン */}
+            <button
+                className="absolute top-4 right-4 text-white/80 hover:text-white transition-colors"
+                onClick={onClose}
+                aria-label="閉じる"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="32"
+                    height="32"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+            </button>
+
+            {/* 画像コンテナ: クリックイベントのバブリングを止めてオーバーレイが閉じないようにする */}
+            <div
+                className="relative max-w-[90vw] max-h-[90vh]"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                    src={src}
+                    alt={alt}
+                    className="max-w-[90vw] max-h-[90vh] object-contain rounded shadow-2xl"
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/components/PostContent/index.tsx
+++ b/src/components/PostContent/index.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState, useRef, useCallback } from 'react';
+import { ImageModal } from '@/components/ImageModal';
+
+type PostContentProps = {
+    contentHtml: string;
+};
+
+type ModalState = {
+    src: string;
+    alt: string;
+} | null;
+
+/**
+ * 記事本文を表示するクライアントコンポーネント
+ * - dangerouslySetInnerHTML で生成されたHTML内の <img> クリックをイベント委譲で検知
+ * - クリックされた画像をモーダルで拡大表示する
+ */
+export function PostContent({ contentHtml }: PostContentProps) {
+    const [modalImage, setModalImage] = useState<ModalState>(null);
+    const articleRef = useRef<HTMLElement>(null);
+
+    // イベント委譲: article 内のどの <img> がクリックされたかを判定する
+    const handleArticleClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'IMG') {
+            const img = target as HTMLImageElement;
+            setModalImage({
+                src: img.src,
+                alt: img.alt || '',
+            });
+        }
+    }, []);
+
+    return (
+        <>
+            <article
+                ref={articleRef}
+                className="prose max-w-none [&_img]:cursor-zoom-in"
+                dangerouslySetInnerHTML={{ __html: contentHtml }}
+                onClick={handleArticleClick}
+            />
+
+            {/* モーダルが開いている場合のみ表示 */}
+            {modalImage && (
+                <ImageModal
+                    src={modalImage.src}
+                    alt={modalImage.alt}
+                    onClose={() => setModalImage(null)}
+                />
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
- ImageModal コンポーネントを追加（ESCキー・オーバーレイクリック・✕ボタンで閉じる）
- PostContent クライアントコンポーネントを追加（イベント委譲で img クリックを検知）
- 記事詳細ページで PostContent を使用するよう変更