### PR TITLE
fix: タグリンクのAccess Deniedエラーを修正

### DIFF
--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -1,4 +1,4 @@
-import { getAllPosts } from '@/lib/posts';
+import { getAllPosts, tagToSlug } from '@/lib/posts';
 import Link from 'next/link';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
@@ -6,17 +6,22 @@ import { Sidebar } from '@/components/Sidebar';
 
 export async function generateStaticParams() {
     const posts = await getAllPosts();
+    // 重複を排除した全タグをスラグ化してパラメータを生成
+    // encodeURIComponentではなくtagToSlugを使い、S3キーとURLのミスマッチを防ぐ
     const tags = new Set(posts.flatMap((p) => p.tags ?? []));
-    return Array.from(tags).map((tag) => ({ tag: encodeURIComponent(tag) }));
+    return Array.from(tags).map((tag) => ({ tag: tagToSlug(tag) }));
 }
 
 export default async function TagPage({ params }: { params: Promise<{ tag: string }> }) {
-    const { tag } = await params;
-    const decodedTag = decodeURIComponent(tag);
+    const { tag: tagSlug } = await params;
 
     const allPosts = await getAllPosts();
+    // スラグから元のタグ名を逆引きする（表示・フィルタリングに使用）
+    const allTags = [...new Set(allPosts.flatMap((p) => p.tags ?? []))];
+    const originalTag = allTags.find((t) => tagToSlug(t) === tagSlug) ?? tagSlug;
+
     const filtered = allPosts
-        .filter((p) => p.tags?.includes(decodedTag))
+        .filter((p) => p.tags?.includes(originalTag))
         .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
     if (filtered.length === 0) notFound();
@@ -26,7 +31,7 @@ export default async function TagPage({ params }: { params: Promise<{ tag: strin
             <main className="flex-1 min-w-0">
                 <h1 className="text-2xl font-bold mb-8 text-gray-600 flex items-center gap-3">
                     <span className="inline-block w-1 h-6 bg-amber-700 rounded-full" aria-hidden="true" />
-                    <span className="text-amber-700">#{decodedTag}</span>
+                    <span className="text-amber-700">#{originalTag}</span>
                     <span className="text-base font-normal text-gray-400">{filtered.length}件</span>
                 </h1>
 
@@ -67,7 +72,7 @@ export default async function TagPage({ params }: { params: Promise<{ tag: strin
                                                 {post.tags.map((t) => (
                                                     <span
                                                         key={t}
-                                                        className={`tag-badge ${t === decodedTag ? 'bg-amber-100 text-amber-800' : ''}`}
+                                                        className={`tag-badge ${t === originalTag ? 'bg-amber-100 text-amber-800' : ''}`}
                                                     >
                                                         {t}
                                                     </span>

--- a/src/components/ImageModal/index.tsx
+++ b/src/components/ImageModal/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useCallback } from 'react';
-import Image from 'next/image';
 
 type ImageModalProps = {
     src: string;

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { getAllPosts } from '@/lib/posts';
+import { getAllPosts, tagToSlug } from '@/lib/posts';
 import { ProfileCard } from '@/components/ProfileCard';
 import Link from 'next/link';
 
@@ -29,7 +29,7 @@ export async function Sidebar() {
                             {sortedTags.map(([tag, count]) => (
                                 <Link
                                     key={tag}
-                                    href={`/tags/${encodeURIComponent(tag)}`}
+                                    href={`/tags/${tagToSlug(tag)}`}
                                     className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-gray-100 text-gray-600 text-xs font-medium hover:bg-amber-100 hover:text-amber-800 transition-colors"
                                 >
                                     {tag}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -9,6 +9,20 @@ import rehypeStringify from 'rehype-stringify';
 
 const postsDirectory = path.join(process.cwd(), 'content/posts');
 
+/**
+ * タグ名をURL-safeなスラグに変換する
+ * 例: "Next.js" → "next-js", "Dynamic Routing" → "dynamic-routing"
+ * ドットとスペースをハイフンに置換し、CloudFrontのファイル拡張子誤認を防ぐ
+ */
+export function tagToSlug(tag: string): string {
+    return tag
+        .toLowerCase()              // 小文字化
+        .replace(/[.\s]+/g, '-')    // ドット・スペースをハイフンに変換
+        .replace(/[^a-z0-9-]/g, '') // 英数字とハイフン以外を除去
+        .replace(/-+/g, '-')        // 連続ハイフンを1つに集約
+        .replace(/^-|-$/g, '');     // 先頭・末尾のハイフンを除去
+}
+
 export type PostMeta = {
     slug: string;
     title: string;


### PR DESCRIPTION
- tagToSlug()関数を追加し、タグ名をURL-safeなスラグに変換する
- "Next.js"→"next-js"のようにドットをハイフンに変換してCloudFrontの 拡張子誤認(.jsをファイルと判定)によるAccess Deniedを防ぐ
- "Dynamic Routing"→"dynamic-routing"のように変換して encodeURIComponentによるS3キーとURLのミスマッチを解消する
- TagPageにてスラグから元のタグ名を逆引きし、フィルタリングと表示に使用
- ImageModalの未使用Imageインポートを削除