### PR TITLE
feat: サイト設定の一元管理と記事ごとの OGP メタデータを実装

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
         run:
             echo "NEXT_PUBLIC_GTM_ID=${{secrets.NEXT_PUBLIC_GTM_ID}}" > .env.production
             echo "NEXT_PUBLIC_CLARITY_ID=${{secrets.NEXT_PUBLIC_CLARITY_ID}}" >> .env.production
+            echo "NEXT_PUBLIC_SITE_URL=${{secrets.NEXT_PUBLIC_SITE_URL}}" >> .env.production
 
       - name: Build Next.js app
         run: npm run build

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Header } from "@/components/Header";
 import { GtmScript } from "@/components/Gtm/GtmScript";
 import ClarityScript from "@/components/Clarity/ClarityScript";
 import { Caveat, Noto_Sans_JP } from "next/font/google";
+import { siteConfig } from "@/config/site";
 
 const caveat = Caveat({
   subsets: ['latin'], // 必要に応じてサブセットを指定
@@ -22,8 +23,29 @@ const notoSansJP = Noto_Sans_JP({
 });
 
 export const metadata: Metadata = {
-  title: "until coffee cools",
-  description: "コーヒーが冷めるまで",
+  /**
+   * metadataBase を設定することで、openGraph.images などに指定した
+   * 相対パス（例: "/heroImage.jpg"）を絶対 URL に自動解決してくれる。
+   * NEXT_PUBLIC_SITE_URL 環境変数がなければ localhost にフォールバック。
+   */
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+  ),
+  title: {
+    /** 各ページは "%s | until coffee cools" 形式になる */
+    template: `%s | ${siteConfig.name}`,
+    default: siteConfig.name,
+  },
+  description: siteConfig.description,
+  openGraph: {
+    siteName: siteConfig.name,
+    locale: "ja_JP",
+    type: "website",
+    images: [{ url: siteConfig.defaultOgImage, alt: siteConfig.name }],
+  },
+  twitter: {
+    card: "summary_large_image",
+  },
 };
 
 export default function RootLayout({
@@ -32,7 +54,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja">
+    <html lang={siteConfig.lang}>
       <head>
         <GtmScript />
         <ClarityScript />

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -2,12 +2,49 @@ import { getAllPosts, getPostData } from '@/lib/posts';
 import { notFound } from 'next/navigation';
 import { Sidebar } from '@/components/Sidebar';
 import { PostContent } from '@/components/PostContent';
+import { siteConfig } from '@/config/site';
+import type { Metadata } from 'next';
 
 type Props = {
     params: Promise<{
         slug: string;
     }>;
 };
+
+/**
+ * 記事ごとの OGP メタデータを生成する。
+ * getPostData（Markdown 処理あり）は重いため、frontmatter のみ読む
+ * getAllPosts を使ってサムネイルや excerpt を取得する。
+ */
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { slug } = await params;
+    const posts = await getAllPosts();
+    const post = posts.find((p) => p.slug === slug);
+
+    // 存在しないスラグは layout のデフォルト metadata にフォールバック
+    if (!post) return {};
+
+    // サムネイルがあればそれを OGP 画像に、なければデフォルト画像を使う
+    const ogImage = post.thumbnail ?? siteConfig.defaultOgImage;
+
+    return {
+        title: post.title,
+        description: post.excerpt,
+        openGraph: {
+            title: post.title,
+            description: post.excerpt,
+            type: "article",
+            publishedTime: post.date,
+            tags: post.tags,
+            images: [{ url: ogImage, alt: post.title }],
+        },
+        twitter: {
+            title: post.title,
+            description: post.excerpt,
+            images: [ogImage],
+        },
+    };
+}
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
     const posts = await getAllPosts();

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -3,6 +3,31 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { Sidebar } from '@/components/Sidebar';
+import { siteConfig } from '@/config/site';
+import type { Metadata } from 'next';
+
+/**
+ * タグページの OGP メタデータを生成する。
+ * スラグから元のタグ名を逆引きしてタイトル・説明文を組み立てる。
+ */
+export async function generateMetadata(
+    { params }: { params: Promise<{ tag: string }> }
+): Promise<Metadata> {
+    const { tag: tagSlug } = await params;
+    const allPosts = await getAllPosts();
+    const allTags = [...new Set(allPosts.flatMap((p) => p.tags ?? []))];
+    const originalTag = allTags.find((t) => tagToSlug(t) === tagSlug) ?? tagSlug;
+
+    return {
+        title: `#${originalTag}`,
+        description: `「${originalTag}」タグの記事一覧`,
+        openGraph: {
+            title: `#${originalTag} | ${siteConfig.name}`,
+            description: `「${originalTag}」タグの記事一覧`,
+            images: [{ url: siteConfig.defaultOgImage, alt: siteConfig.name }],
+        },
+    };
+}
 
 export async function generateStaticParams() {
     const posts = await getAllPosts();

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,14 +1,15 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { siteConfig } from '@/config/site';
 
 export function Footer({ className }: { className: string }) {
     return (
         <footer className={`p-6 text-center text-gray-500 ${className} flex items-center justify-center`}> {/* flex-colを削除し、横並びにして中央揃え */}
             <div> {/* mb-2を削除 */}
-                &copy; {new Date().getFullYear()} untilcoffeecools
+                &copy; {new Date().getFullYear()} {siteConfig.copyrightName}
             </div>
             <div className="ml-4"> {/* 左にマージンを追加してコピーライトとの間にスペースを作る */}
-                <Link href="https://github.com/endy-key/untilcoffeecools" target="_blank" rel="noopener noreferrer" aria-label="GitHub Repository" title="GitHub Repository">
+                <Link href={siteConfig.links.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Repository" title="GitHub Repository">
                     <Image
                         src="/github-mark.svg" // publicディレクトリからのパス
                         alt="GitHub Icon"

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { siteConfig } from '@/config/site';
 
 function HomeIcon() {
     return (
@@ -44,7 +45,7 @@ export function Header({ className }: { className: string }) {
                     href="/"
                     className={`text-2xl font-bold text-amber-700 hover:text-amber-600 transition-colors tracking-wider ${className}`}
                 >
-                    until coffee cools
+                    {siteConfig.name}
                 </Link>
 
                 {/* Navigation */}

--- a/src/components/HeroSection/index.tsx
+++ b/src/components/HeroSection/index.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { PlainHomeSvg } from '@/components/Animation/PlainHomeSvg';
+import { siteConfig } from '@/config/site';
 
 interface Particle {
     id: number;
@@ -67,7 +68,7 @@ export function HeroSection() {
                 <div className="hero-logo">
                     <PlainHomeSvg />
                 </div>
-                <p className="hero-tagline">Pause and explore.</p>
+                <p className="hero-tagline">{siteConfig.tagline}</p>
             </div>
 
             {/* Bottom gradient fade to page background */}

--- a/src/components/ProfileCard/index.tsx
+++ b/src/components/ProfileCard/index.tsx
@@ -1,19 +1,20 @@
 import React from "react";
 import Image from "next/image";
+import { siteConfig } from "@/config/site";
 
 export function ProfileCard() {
     return (
         <div className="bg-white rounded-lg p-4 shadow-md">
             <Image
-                src="/avatar.jpg"
+                src={siteConfig.author.avatar}
                 alt="アバターアイコン"
                 className="w-15 h-15 rounded-full mx-auto"
                 width={80}
                 height={80}
             />
-            <h2 className="mt-3 text-center text-lg font-bold">Y.E.</h2>
+            <h2 className="mt-3 text-center text-lg font-bold">{siteConfig.author.name}</h2>
             <p className="mt-1 text-center text-sm text-gray-500">
-                コーヒー、自作キーボード、観葉植物に囲まれた生活をしてます。
+                {siteConfig.author.bio}
             </p>
         </div>
     );

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,45 @@
+/**
+ * サイト全体の設定を一元管理するファイル。
+ * タイトル・著者情報・SNSリンクなど、複数箇所で使われる定数はここに定義し、
+ * 各コンポーネントはここから import して使う。
+ */
+export const siteConfig = {
+  /** ブラウザタブや OGP に表示されるサイト名 */
+  name: "until coffee cools",
+
+  /** サイトの説明文（メタディスクリプション・OGP 用） */
+  description: "コーヒーが冷めるまで",
+
+  /** HTML の lang 属性 */
+  lang: "ja",
+
+  /** フッターの copyright 表示名 */
+  copyrightName: "untilcoffeecools",
+
+  /** ヒーローセクションのキャッチコピー */
+  tagline: "Pause and explore.",
+
+  /** 著者プロフィール */
+  author: {
+    /** 表示名 */
+    name: "Y.E.",
+    /** 自己紹介文 */
+    bio: "コーヒー、自作キーボード、観葉植物に囲まれた生活をしてます。",
+    /** アバター画像のパス（public/ からの相対パス） */
+    avatar: "/avatar.jpg",
+  },
+
+  /** 外部リンク */
+  links: {
+    github: "https://github.com/endy-key/untilcoffeecools",
+  },
+
+  /** OGP 画像のデフォルト（記事にサムネイルがない場合のフォールバック） */
+  defaultOgImage: "/heroImage.jpg",
+} as const;
+
+/**
+ * 本番環境かどうかを判定するフラグ。
+ * gtm.ts / clarity.ts など複数箇所で使っていたものをここに一本化。
+ */
+export const isProduction = process.env.NODE_ENV === "production";

--- a/src/lib/clarity.ts
+++ b/src/lib/clarity.ts
@@ -1,4 +1,4 @@
 // lib/clarity.ts
-export const CLARITY_ID = process.env.NEXT_PUBLIC_CLARITY_ID ?? "";
+export { isProduction } from "@/config/site";
 
-export const isProduction = process.env.NODE_ENV === "production";
+export const CLARITY_ID = process.env.NEXT_PUBLIC_CLARITY_ID ?? "";

--- a/src/lib/gtm.ts
+++ b/src/lib/gtm.ts
@@ -1,4 +1,4 @@
 // lib/gtm.ts
-export const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID ?? "";
+export { isProduction } from "@/config/site";
 
-export const isProduction = process.env.NODE_ENV === "production";
+export const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID ?? "";


### PR DESCRIPTION
- config/site.ts を新規作成しサイト名・著者情報・外部リンク等を一元管理
- 各コンポーネント（Header/Footer/ProfileCard/HeroSection）のハードコード値を siteConfig から参照するよう変更
- gtm.ts / clarity.ts で重複していた isProduction を config/site.ts に統合
- posts/[slug] に generateMetadata を追加（title / description / OGP / Twitter Card）
- tags/[tag] に generateMetadata を追加
- layout.tsx に metadataBase とデフォルト OGP を設定
- deploy.yml に NEXT_PUBLIC_SITE_URL シークレットを追加